### PR TITLE
feat: add empirical permutation p-value to percentile output

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ Parses variants and reading frames from the data folder, producing `variants.csv
 - `--s <sim_file>`: path to the simulated file (defaults to `harmonic_mean_best_ranks_simulated.csv` or `per_allele_best_ranks_simulated.csv` depending on mode).
 - `--o <obs_file>`: path to the observed file (defaults to the most recent matching file in the data folder, excluding `_simulated`).
 - Observed variants are excluded from the simulated distribution before computing percentiles.
-- Writes `percentile_harmonic_mean_best_ranks.csv` or `percentile_per_allele_best_ranks.csv` to the data folder. Columns added: `Percentile` (0–100), `Z_i` (per-variant normal quantile of the percentile), and `p_value` (empty for individual variants). A final `combined_z` row is appended with the mean percentile, Stouffer's combined Z score, and the one-tailed p-value summarising whether the variant set is collectively more escape-prone than the simulated distribution.
+- Writes `percentile_harmonic_mean_best_ranks.csv` or `percentile_per_allele_best_ranks.csv` to the data folder. Columns added: `Percentile` (0–100), `Z_i` (per-variant normal quantile of the percentile), and `p_value` (empty for individual variants). Two summary rows are appended:
+  - `combined_z`: Stouffer's combined Z score (parametric), mean percentile across all k variants, and a one-tailed p-value.
+  - `empirical_p`: empirical p-value from 9999 random draws of k variants (without replacement) from the simulated distribution, comparing their mean percentile to the observed mean percentile. Provides a non-parametric complement to Stouffer's Z.
 
 ### Global Options
 
@@ -203,8 +205,8 @@ These options allow multiple independent analyses (e.g. observed vs. simulated) 
 - `per_allele_best_ranks.csv`: Per-allele eluted ligand best ranks and log2 fold changes for every allele in the genome, filtered to ancestral EL rank ≤ 2% (`Frame`, `Locus`, `Mutation`, `MHC`, `ELBR_A`, `ELBR_D`, `foldchange_BR`, `log2_foldchange_BR`). Written when `--per-allele` is passed to `run` or `run_supertype`.
 - `variants_simulated.csv`, `harmonic_mean_best_ranks_simulated.csv`: Simulated variant data and HMBR results (produced by `simulate` + `run`).
 - `per_allele_best_ranks_simulated.csv`: Per-allele results for simulated variants (produced by `simulate` + `run --per-allele`).
-- `percentile_harmonic_mean_best_ranks.csv`: Observed HMBR with `Percentile`, `Z_i`, and `p_value` columns relative to the simulated distribution, plus a `combined_z` summary row (Stouffer's Z, mean percentile, one-tailed p-value).
-- `percentile_per_allele_best_ranks.csv`: Observed per-allele fold changes with the same Stouffer columns (written by `percentile --per-allele`).
+- `percentile_harmonic_mean_best_ranks.csv`: Observed HMBR with `Percentile`, `Z_i`, and `p_value` columns relative to the simulated distribution, plus `combined_z` (Stouffer's Z, mean percentile, one-tailed p-value) and `empirical_p` (empirical p-value from 9999 random k-samples) summary rows.
+- `percentile_per_allele_best_ranks.csv`: Observed per-allele fold changes with the same columns and summary rows (written by `percentile --per-allele`).
 
 ## Advanced Configuration
 

--- a/src/percentile.jl
+++ b/src/percentile.jl
@@ -281,6 +281,35 @@ if abspath(PROGRAM_FILE) == @__FILE__
         println("Stouffer Z=$(round(Z_combined, digits=4))  p=$(round(p_combined, digits=6))  N=$(N_z)")
     end
 
+    # Empirical permutation test: sample 9999 sets of k from sim_vals, compare mean percentile
+    n_perm = 9999
+    if !isempty(valid_perc) && !isempty(sim_vals)
+        k_obs = length(valid_perc)
+        obs_mean_perc = sum(valid_perc) / k_obs
+        if length(sim_vals) < k_obs
+            println("Warning: sim pool ($(length(sim_vals))) < k ($(k_obs)); skipping empirical_p.")
+        else
+            local exceed_count = 0
+            for _ in 1:n_perm
+                samp = sample(sim_vals, k_obs; replace=false)
+                samp_mean_perc = sum(100.0 * F(v) for v in samp) / k_obs
+                if samp_mean_perc >= obs_mean_perc
+                    exceed_count += 1
+                end
+            end
+            p_empirical = exceed_count / n_perm
+            emp_vals = Dict{Symbol, Any}(Symbol(col) => missing for col in names(obs_df))
+            emp_vals[:Percentile] = obs_mean_perc
+            emp_vals[:p_value]    = p_empirical
+            if haskey(emp_vals, :Mutation)
+                emp_vals[:Mutation] = "empirical_p"
+            end
+            emp_row = DataFrame(Dict(kk => [vv] for (kk, vv) in emp_vals))
+            obs_df = vcat(obs_df, emp_row, cols=:union)
+            println("Empirical p=$(round(p_empirical, digits=6))  k=$(k_obs)  N_sim=$(length(sim_vals))  n_perm=$(n_perm)")
+        end
+    end
+
     # Write output next to observed, carrying through observed suffix
     out_suffix = _suffix_from_observed(obs_path, base_name)
     out_name = isempty(out_suffix) ? string(out_prefix, ".csv") : string(out_prefix, "_", out_suffix, ".csv")


### PR DESCRIPTION
Appends an empirical_p summary row alongside combined_z in the percentile output CSV. The empirical p-value is derived from 9999 without-replacement samples of k variants from the simulated distribution, comparing their mean percentile to the observed mean percentile. Provides a non-parametric complement to Stouffer's Z.

Also fixes a soft-scope warning for exceed_count in the permutation loop.