### PR TITLE
Same locus substitutions

### DIFF
--- a/CD8scape.jl
+++ b/CD8scape.jl
@@ -124,7 +124,7 @@ end
 # Process "prep" command
 if command == "prep"
     # Setup environment
-    if !safe_run(`julia --project=. src/env.jl`)
+    if !safe_run(`julia --startup-file=no --project=. src/env.jl`)
         println("Error running src/env.jl")
         exit(1)
     end
@@ -144,13 +144,13 @@ elseif command == "read"
     variants_csv_path = resolve_write(joinpath(folder_path, "variants.csv"); suffix=suffix)
 
     # Read frames (NCBI first, then Samfire fallback)
-    local read_ncbi_cmd = `julia --project=. src/read_ncbi_frames.jl $folder_path`
+    local read_ncbi_cmd = `julia --startup-file=no --project=. src/read_ncbi_frames.jl $folder_path`
     if suffix != ""; read_ncbi_cmd = `$read_ncbi_cmd --suffix $suffix`; end
     if latest; read_ncbi_cmd = `$read_ncbi_cmd --latest`; else read_ncbi_cmd = `$read_ncbi_cmd --no-latest`; end
     ncbi_success = safe_run(read_ncbi_cmd)
     if !ncbi_success || !isfile(frames_csv_path)
         println("read_ncbi_frames.jl failed or frames.csv not found. Trying read_samfire_frames.jl instead.")
-        local read_sam_cmd = `julia --project=. src/read_samfire_frames.jl $folder_path`
+        local read_sam_cmd = `julia --startup-file=no --project=. src/read_samfire_frames.jl $folder_path`
         if suffix != ""; read_sam_cmd = `$read_sam_cmd --suffix $suffix`; end
         if latest; read_sam_cmd = `$read_sam_cmd --latest`; else read_sam_cmd = `$read_sam_cmd --no-latest`; end
         samfire_success = safe_run(read_sam_cmd)
@@ -164,7 +164,7 @@ elseif command == "read"
     parse_ok = false
     if use_aa
         # --aa flag: parse amino-acid-level variants from a .aa file
-        local parse_aa_cmd = `julia --project=. src/parse_aa_variants.jl $folder_path`
+        local parse_aa_cmd = `julia --startup-file=no --project=. src/parse_aa_variants.jl $folder_path`
         if suffix != ""; parse_aa_cmd = `$parse_aa_cmd --suffix $suffix`; end
         if latest; parse_aa_cmd = `$parse_aa_cmd --latest`; else parse_aa_cmd = `$parse_aa_cmd --no-latest`; end
         parse_ok = safe_run(parse_aa_cmd)
@@ -175,7 +175,7 @@ elseif command == "read"
         # Prefer VCF if present, otherwise trajectories
         vcf_files = filter(f -> endswith(f, ".vcf") || endswith(f, ".vcf.gz"), readdir(folder_path; join=true))
         if !isempty(vcf_files)
-            local parse_vcf_cmd = `julia --project=. src/parse_vcf.jl $folder_path`
+            local parse_vcf_cmd = `julia --startup-file=no --project=. src/parse_vcf.jl $folder_path`
             if suffix != ""; parse_vcf_cmd = `$parse_vcf_cmd --suffix $suffix`; end
             parse_ok = safe_run(parse_vcf_cmd)
             if !parse_ok
@@ -183,7 +183,7 @@ elseif command == "read"
             end
         end
         if !parse_ok
-            local parse_traj_cmd = `julia --project=. src/parse_trajectories.jl $folder_path`
+            local parse_traj_cmd = `julia --startup-file=no --project=. src/parse_trajectories.jl $folder_path`
             if suffix != ""; parse_traj_cmd = `$parse_traj_cmd --suffix $suffix`; end
             parse_ok = safe_run(parse_traj_cmd)
         end
@@ -213,13 +213,13 @@ elseif command == "simulate"
     frames_csv_path = resolve_write(joinpath(folder_path, "frames.csv"); suffix=suffix)
 
     # Try NCBI frame reading first
-    local read_ncbi_cmd = `julia --project=. src/read_ncbi_frames.jl $folder_path`
+    local read_ncbi_cmd = `julia --startup-file=no --project=. src/read_ncbi_frames.jl $folder_path`
     if suffix != ""; read_ncbi_cmd = `$read_ncbi_cmd --suffix $suffix`; end
     if latest; read_ncbi_cmd = `$read_ncbi_cmd --latest`; else read_ncbi_cmd = `$read_ncbi_cmd --no-latest`; end
     ncbi_success = safe_run(read_ncbi_cmd)
     if !ncbi_success || !isfile(frames_csv_path)
         println("read_ncbi_frames.jl failed or frames.csv not found. Trying read_samfire_frames.jl instead.")
-        local read_sam_cmd = `julia --project=. src/read_samfire_frames.jl $folder_path`
+        local read_sam_cmd = `julia --startup-file=no --project=. src/read_samfire_frames.jl $folder_path`
         if suffix != ""; read_sam_cmd = `$read_sam_cmd --suffix $suffix`; end
         if latest; read_sam_cmd = `$read_sam_cmd --latest`; else read_sam_cmd = `$read_sam_cmd --no-latest`; end
         samfire_success = safe_run(read_sam_cmd)
@@ -230,7 +230,7 @@ elseif command == "simulate"
     end
 
     # Forward extra arguments to simulate_variants.jl
-    local sim_cmd = `julia --project=. src/simulate_variants.jl $folder_path`
+    local sim_cmd = `julia --startup-file=no --project=. src/simulate_variants.jl $folder_path`
     for arg in extra_args
         sim_cmd = `$sim_cmd $arg`
     end
@@ -269,7 +269,7 @@ elseif command == "run"
     skip_marker = joinpath(folder_path, ".cd8scape_skipped")
 
     # Generate Peptides
-        local gen_cmd = `julia --project=. src/generate_peptides.jl $folder_path`
+        local gen_cmd = `julia --startup-file=no --project=. src/generate_peptides.jl $folder_path`
         if suffix != ""; gen_cmd = `$gen_cmd --suffix $suffix`; end
         if latest; gen_cmd = `$gen_cmd --latest`; else gen_cmd = `$gen_cmd --no-latest`; end
         if !safe_run(gen_cmd)
@@ -278,7 +278,7 @@ elseif command == "run"
     end
 
     # Clean Peptides
-    if !safe_run(`julia --project=. src/clean_peptides.jl $folder_path`)
+    if !safe_run(`julia --startup-file=no --project=. src/clean_peptides.jl $folder_path`)
         println("Error running src/clean_peptides.jl")
         exit(1)
     end
@@ -299,7 +299,7 @@ elseif command == "run"
     end
 
     # Run NetMHCpan
-    local run_cmd = `julia --project=. src/run_netMHCpan.jl --folder $folder_path`
+    local run_cmd = `julia --startup-file=no --project=. src/run_netMHCpan.jl --folder $folder_path`
     for t in threads_arg
         run_cmd = `$run_cmd $t`
     end
@@ -353,7 +353,7 @@ elseif command == "run"
     end
 
     # Process Scores
-    local scores_cmd = `julia --project=. src/process_scores.jl --folder $folder_path`
+    local scores_cmd = `julia --startup-file=no --project=. src/process_scores.jl --folder $folder_path`
     if suffix != ""; scores_cmd = `$scores_cmd --suffix $suffix`; end
     if latest; scores_cmd = `$scores_cmd --latest`; else scores_cmd = `$scores_cmd --no-latest`; end
     if !safe_run(scores_cmd)
@@ -362,7 +362,7 @@ elseif command == "run"
     end
 
     # Process Best Ranks
-    local ranks_cmd = `julia --project=. src/process_best_ranks.jl $folder_path`
+    local ranks_cmd = `julia --startup-file=no --project=. src/process_best_ranks.jl $folder_path`
     if suffix != ""; ranks_cmd = `$ranks_cmd --suffix $suffix`; end
     if latest; ranks_cmd = `$ranks_cmd --latest`; else ranks_cmd = `$ranks_cmd --no-latest`; end
     if per_allele; ranks_cmd = `$ranks_cmd --per-allele`; end
@@ -404,7 +404,7 @@ elseif command == "run_supertype"
     skip_marker = joinpath(folder_path, ".cd8scape_skipped")
 
     # Generate Peptides
-    local gen_cmd = `julia --project=. src/generate_peptides.jl $folder_path`
+    local gen_cmd = `julia --startup-file=no --project=. src/generate_peptides.jl $folder_path`
     if suffix != ""; gen_cmd = `$gen_cmd --suffix $suffix`; end
     if latest; gen_cmd = `$gen_cmd --latest`; else gen_cmd = `$gen_cmd --no-latest`; end
     if !safe_run(gen_cmd)
@@ -413,7 +413,7 @@ elseif command == "run_supertype"
     end
 
     # Clean Peptides
-    if !safe_run(`julia --project=. src/clean_peptides.jl $folder_path`)
+    if !safe_run(`julia --startup-file=no --project=. src/clean_peptides.jl $folder_path`)
         println("Error running src/clean_peptides.jl")
         exit(1)
     end
@@ -434,7 +434,7 @@ elseif command == "run_supertype"
     end
 
     # Run NetMHCpan
-    local run_cmd = `julia --project=. src/run_netMHCpan_global.jl --folder $folder_path`
+    local run_cmd = `julia --startup-file=no --project=. src/run_netMHCpan_global.jl --folder $folder_path`
     for t in threads_arg
         run_cmd = `$run_cmd $t`
     end
@@ -487,7 +487,7 @@ elseif command == "run_supertype"
     end
 
     # Process Scores
-    local scores_cmd = `julia --project=. src/process_scores.jl --folder $folder_path`
+    local scores_cmd = `julia --startup-file=no --project=. src/process_scores.jl --folder $folder_path`
     if suffix != ""; scores_cmd = `$scores_cmd --suffix $suffix`; end
     if latest; scores_cmd = `$scores_cmd --latest`; else scores_cmd = `$scores_cmd --no-latest`; end
     if !safe_run(scores_cmd)
@@ -496,7 +496,7 @@ elseif command == "run_supertype"
     end
 
     # Process Best Ranks
-    local ranks_cmd = `julia --project=. src/process_best_ranks.jl $folder_path`
+    local ranks_cmd = `julia --startup-file=no --project=. src/process_best_ranks.jl $folder_path`
     if suffix != ""; ranks_cmd = `$ranks_cmd --suffix $suffix`; end
     if latest; ranks_cmd = `$ranks_cmd --latest`; else ranks_cmd = `$ranks_cmd --no-latest`; end
     if per_allele; ranks_cmd = `$ranks_cmd --per-allele`; end
@@ -537,7 +537,7 @@ elseif command == "percentile"
     forward = _parse_s_o(extra_args)
     per_allele = any(a -> a == "--per-allele", extra_args)
 
-    local pct_cmd = `julia --project=. src/percentile.jl $folder_path`
+    local pct_cmd = `julia --startup-file=no --project=. src/percentile.jl $folder_path`
     for f in forward
         pct_cmd = `$pct_cmd $f`
     end

--- a/src/generate_peptides.jl
+++ b/src/generate_peptides.jl
@@ -203,36 +203,63 @@ function check_locus(df::DataFrame)::DataFrame
     for row in eachrow(df)
         ref = String(row.Consensus)
         alt = String(row.Variant)
-        r, a, prefix_trim = normalize_variant(ref, alt)
-        adj = row.Locus + prefix_trim
-        # Compute Relative_Locus from adjusted position
-        rl = adj - row.Start + 1
-        # If ref does not match at the adjusted position, try to find nearby match
-        ref_match = false
-        if 1 ≤ rl && rl + length(r) - 1 ≤ length(row.Consensus_sequence)
-            ref_match = row.Consensus_sequence[rl:(rl + length(r) - 1)] == r
-        end
-        if !ref_match
-            # allow a small number of mismatches to tolerate minor ref discrepancies
-            new_rl, ok = find_ref_match(row.Consensus_sequence, r, rl; window=10, max_mismatch=1)
-            if ok
-                adj = row.Start + new_rl - 1
-                rl = new_rl
-                if 1 ≤ rl && rl + length(r) - 1 ≤ length(row.Consensus_sequence)
-                    r = row.Consensus_sequence[rl:(rl + length(r) - 1)]
+
+        # Before normalizing, check whether the FULL original ref matches the consensus
+        # at the given locus.  normalize_variant trims shared suffix/prefix, potentially
+        # reducing a 3-nt codon to a single nucleotide.  If the frame has been overwritten
+        # by a later same-locus variant (last-write-wins), find_ref_match will then locate
+        # that single nucleotide at the WRONG codon position (or accept a mismatch via
+        # max_mismatch=1), corrupting the variant into a synonymous or mislabelled change.
+        # By checking the full ref first we can skip normalization and ref-searching
+        # entirely for overwritten loci, trusting the locus and codon from variants.csv
+        # instead.  edit_ancestral_sequence then patches the ancestral sequence per-row.
+        orig_rl       = row.Locus - row.Start + 1
+        full_ref_len  = length(ref)
+        full_ref_ok   = (1 ≤ orig_rl &&
+                         orig_rl + full_ref_len - 1 ≤ length(row.Consensus_sequence) &&
+                         row.Consensus_sequence[orig_rl:(orig_rl + full_ref_len - 1)] == ref)
+
+        r, a, adj, rl, ref_match = if full_ref_ok
+            # Normal path: normalize the variant (trim shared suffix/prefix) and
+            # optionally realign with find_ref_match for minor ref discrepancies.
+            rn, an, prefix_trim = normalize_variant(ref, alt)
+            adjn  = row.Locus + prefix_trim
+            rln   = adjn - row.Start + 1
+            rn_match = (1 ≤ rln &&
+                        rln + length(rn) - 1 ≤ length(row.Consensus_sequence) &&
+                        row.Consensus_sequence[rln:(rln + length(rn) - 1)] == rn)
+            if !rn_match
+                new_rln, ok = find_ref_match(row.Consensus_sequence, rn, rln;
+                                             window=10, max_mismatch=1)
+                if ok
+                    adjn = row.Start + new_rln - 1
+                    rln  = new_rln
+                    if 1 ≤ rln && rln + length(rn) - 1 ≤ length(row.Consensus_sequence)
+                        rn = row.Consensus_sequence[rln:(rln + length(rn) - 1)]
+                    end
+                    rn_match = true
+                else
+                    ref_len = length(rn)
+                    if 1 ≤ rln && rln + ref_len - 1 ≤ length(row.Consensus_sequence)
+                        rn = row.Consensus_sequence[rln:(rln + ref_len - 1)]
+                        rn_match = true
+                        @warn "Reference allele mismatch at Locus $(row.Locus). Normalizing REF to consensus sequence."
+                    end
                 end
-                ref_match = true
-            else
-                # Do NOT overwrite r with the consensus here.  When multiple variants share
-                # the same locus (e.g. reversals or multi-ancestral sets), parse_aa_variants
-                # writes each ancestral codon into frames sequentially, so the last write
-                # wins.  Replacing r with whatever the consensus now says would corrupt
-                # earlier variants into synonymous (or wrong) changes.  Instead, trust the
-                # ref carried in variants.csv and let edit_ancestral_sequence patch the
-                # correct ancestral codon into the sequence on a per-row basis.
-                @warn "Reference allele mismatch at Locus $(row.Locus): REF '$(r)' not found in consensus. Using REF from variants.csv as-is (may indicate a same-locus multi-ancestral variant)."
             end
+            (rn, an, adjn, rln, rn_match)
+        else
+            # The full ref does not match at this locus — the frame was likely overwritten
+            # by a later same-locus variant.  Skip normalization and find_ref_match to
+            # avoid false positives, and use the original locus + full ref/alt from
+            # variants.csv.  edit_ancestral_sequence will patch the correct ancestral codon.
+            @warn "Reference allele mismatch at Locus $(row.Locus): " *
+                  "REF '$(ref)' not found in consensus at relative position $(orig_rl) " *
+                  "(same-locus multi-ancestral variant — frame overwritten by a later record). " *
+                  "Using variants.csv ref and locus as-is."
+            (ref, alt, row.Locus, orig_rl, false)
         end
+
         push!(norm_ref, r)
         push!(norm_alt, a)
         push!(adjusted_locus, adj)

--- a/src/generate_peptides.jl
+++ b/src/generate_peptides.jl
@@ -223,13 +223,14 @@ function check_locus(df::DataFrame)::DataFrame
                 end
                 ref_match = true
             else
-                # normalize against consensus at the adjusted locus
-                ref_len = length(r)
-                if 1 ≤ rl && rl + ref_len - 1 ≤ length(row.Consensus_sequence)
-                    r = row.Consensus_sequence[rl:(rl + ref_len - 1)]
-                    ref_match = true
-                    @warn "Reference allele mismatch at Locus $(row.Locus). Normalizing REF to consensus sequence."
-                end
+                # Do NOT overwrite r with the consensus here.  When multiple variants share
+                # the same locus (e.g. reversals or multi-ancestral sets), parse_aa_variants
+                # writes each ancestral codon into frames sequentially, so the last write
+                # wins.  Replacing r with whatever the consensus now says would corrupt
+                # earlier variants into synonymous (or wrong) changes.  Instead, trust the
+                # ref carried in variants.csv and let edit_ancestral_sequence patch the
+                # correct ancestral codon into the sequence on a per-row basis.
+                @warn "Reference allele mismatch at Locus $(row.Locus): REF '$(r)' not found in consensus. Using REF from variants.csv as-is (may indicate a same-locus multi-ancestral variant)."
             end
         end
         push!(norm_ref, r)
@@ -269,36 +270,56 @@ end
 """
     edit_ancestral_sequence(df::DataFrame) :: DataFrame
 
-Edits the ancestral (consensus) sequence at the relative locus to produce a derived sequence.
+Builds per-row ancestral and derived nucleotide sequences.
+
+For every row the ref codon from variants.csv (Normalized_Consensus) is spliced into
+the frame's Consensus_sequence at Relative_Locus to produce Ancestral_sequence.  The
+derived codon (Normalized_Variant) is then spliced in at the same position to produce
+Derived_sequence.
+
+Splicing the ref from variants.csv rather than relying on whatever the frame consensus
+already has at that position is essential when multiple variants share a locus (e.g.
+reversals or multi-ancestral sets).  parse_aa_variants writes each ancestral codon into
+frames sequentially, so only the last one is retained; all earlier rows would otherwise
+inherit the wrong ancestral codon.  By patching on a per-row basis we ensure both
+ancestral and derived sequences are correct for every variant independently of write order.
 
 # Arguments
 - df::DataFrame: Input DataFrame after check_locus.
 
 # Returns
-- A DataFrame with a new 'Derived_sequence' column.
+- A DataFrame with new 'Ancestral_sequence' and 'Derived_sequence' columns.
 """
 function edit_ancestral_sequence(df::DataFrame)::DataFrame
-    df[!, :Derived_sequence] = similar(df.Consensus_sequence)
+    df[!, :Ancestral_sequence] = similar(df.Consensus_sequence)
+    df[!, :Derived_sequence]   = similar(df.Consensus_sequence)
     for row in eachrow(df)
         rl = row.Relative_Locus
-        consensus = row.Consensus_sequence
-        variant_nt = String(row.Normalized_Variant)
-        ref_nt = String(row.Normalized_Consensus)
+        consensus   = row.Consensus_sequence
+        ref_nt      = String(row.Normalized_Consensus)
+        variant_nt  = String(row.Normalized_Variant)
 
         if !ismissing(rl) && 1 ≤ rl ≤ length(consensus)
-            ref_len = length(ref_nt)
-            seq_len = length(consensus)
-            if rl + ref_len - 1 ≤ seq_len && consensus[rl:(rl + ref_len - 1)] == ref_nt
-                prefix = rl > 1 ? consensus[1:(rl - 1)] : ""
-                suffix_start = rl + ref_len
-                suffix = suffix_start ≤ seq_len ? consensus[suffix_start:end] : ""
-                row.Derived_sequence = string(prefix, variant_nt, suffix)
+            ref_len      = length(ref_nt)
+            seq_len      = length(consensus)
+            suffix_start = rl + ref_len
+
+            if suffix_start - 1 ≤ seq_len
+                prefix  = rl > 1       ? consensus[1:(rl - 1)]   : ""
+                suffix  = suffix_start ≤ seq_len ? consensus[suffix_start:end] : ""
+                # Always patch the consensus with the variants.csv ref at this locus.
+                # This corrects for cases where frames.csv has been overwritten by a
+                # later same-locus record (the last-write-wins problem).
+                row.Ancestral_sequence = string(prefix, ref_nt,     suffix)
+                row.Derived_sequence   = string(prefix, variant_nt, suffix)
             else
-                @warn "Reference allele mismatch or out of bounds at Locus $(row.Locus). Keeping consensus sequence."
-                row.Derived_sequence = consensus
+                @warn "Ref allele out of bounds at Locus $(row.Locus). Keeping consensus sequence for both ancestral and derived."
+                row.Ancestral_sequence = consensus
+                row.Derived_sequence   = consensus
             end
         else
-            row.Derived_sequence = consensus
+            row.Ancestral_sequence = consensus
+            row.Derived_sequence   = consensus
         end
     end
     return df
@@ -320,8 +341,11 @@ function translate_sequences(df::DataFrame)::DataFrame
         join([get(CODON_DICT, uppercase(dna_sequence[i:i+2]), "?") 
               for i in 1:3:length(dna_sequence)-2], "")
     
-    df[!, :Ancestral_AA_sequence] = [translate_dna_to_protein(seq) for seq in df.Consensus_sequence]
-    df[!, :Derived_AA_sequence] = [translate_dna_to_protein(seq) for seq in df.Derived_sequence]
+    # Use Ancestral_sequence (patched per-row by edit_ancestral_sequence) rather than
+    # Consensus_sequence so that same-locus variants with different ancestral amino acids
+    # each get the correct ancestral translation.
+    df[!, :Ancestral_AA_sequence] = [translate_dna_to_protein(seq) for seq in df.Ancestral_sequence]
+    df[!, :Derived_AA_sequence]   = [translate_dna_to_protein(seq) for seq in df.Derived_sequence]
     return df
 end
 

--- a/src/parse_aa_variants.jl
+++ b/src/parse_aa_variants.jl
@@ -178,7 +178,15 @@ function main()
         exit(1)
     end
 
-    # Build variants, forcing canonical codons regardless of consensus
+    # Build variants, forcing canonical codons regardless of consensus.
+    # Track the ancestral codon written into frames for each locus so we can warn when
+    # multiple records at the same locus carry different ancestral amino acids (e.g.
+    # reversals like I->L and L->I, or multi-ancestral sets like I->K / T->I / K->T).
+    # The frame can only hold one codon per position, so later records overwrite earlier
+    # ones; generate_peptides.jl now handles this by patching ancestral on a per-row
+    # basis from the Consensus column in variants.csv.
+    locus_ancestral = Dict{Int, String}()  # locus => canonical ancestral codon first seen
+
     out = DataFrame(Locus=Int[], Consensus=String[], Variant=String[])
 
     for rec in records
@@ -243,6 +251,21 @@ function main()
 
         # Absolute nucleotide locus (start of the codon in genome coordinates)
         locus = start_pos + rel_nt - 1
+
+        # Warn when multiple records share a locus with different ancestral amino acids.
+        # Only the last ancestral codon written here will persist in frames.csv, but
+        # generate_peptides.jl now patches each row's ancestral sequence independently
+        # from the Consensus column in variants.csv, so all variants are handled correctly.
+        if haskey(locus_ancestral, locus) && locus_ancestral[locus] != ancestral_codon
+            prev = locus_ancestral[locus]
+            prev_aa = get(CODON_DICT, prev, "?")
+            @warn "Same-locus multi-ancestral variant at locus $locus ($(rec.orf_name) AA $(rec.aa_pos)): " *
+                  "previously saw ancestral codon '$prev' ($prev_aa), now '$(ancestral_codon)' ($(rec.ancestral_aa)). " *
+                  "This is expected for reversals or multi-ancestral sets. " *
+                  "frames.csv will carry the last-written codon ('$(ancestral_codon)'); " *
+                  "generate_peptides.jl will patch each variant's ancestral codon independently."
+        end
+        locus_ancestral[locus] = ancestral_codon
 
         push!(out, (locus, ancestral_codon, derived_codon))
         println("  $(rec.orf_name) AA $(rec.aa_pos): $(rec.ancestral_aa)→$(rec.derived_aa) | codon $ancestral_codon→$derived_codon | locus $locus")


### PR DESCRIPTION
Fix silent loss/corruption of same-locus variants with different ancestral AAs

## Problem

When multiple records in a `.aa` file share a position (e.g. reversals like `I↔L`, or multi-ancestral sets like `I→K` / `T→I` / `K→T`), `parse_aa_variants.jl` writes each ancestral codon into `frames.csv` sequentially. Only the last write survives.

`generate_peptides.jl` then used that stale consensus as the ancestral for all rows at that locus. Two failure modes, both silent:

- **Dropped** — the earlier variant's ref no longer matched the frame. `normalize_variant` reduced the 3-nt codon difference to a single nucleotide, and `find_ref_match` (with `max_mismatch=1`) located it at the wrong codon position or accepted a mismatch, collapsing ref and alt to the same value → synonymous → filtered out.
- **Mislabelled** — where the normalised ref differed from the alt, the variant survived but with the wrong ancestral AA.

Verified on H3N2 HA (`attempt_4`): previously only `L3I` was produced at position 3 (`I→L` dropped); at position 160, `I→K` was dropped and `T→I` was silently relabelled as `K→I`.

## Fix

**`generate_peptides.jl`** — two changes:

1. `check_locus`: before normalizing, check whether the **full original ref codon** matches the consensus at the given locus. If it does, proceed with normalization and `find_ref_match` as before (no regression). If it doesn't, skip both — the locus and full ref/alt from `variants.csv` are used directly, avoiding false-positive partial matches.

2. `edit_ancestral_sequence`: always splices the `variants.csv` ref codon into the frame sequence at `Relative_Locus` on a per-row basis to build `Ancestral_sequence`, rather than relying on whatever the frame currently holds. `translate_sequences` now translates `Ancestral_sequence` instead of `Consensus_sequence`.

**`parse_aa_variants.jl`**: emits an explicit warning when a later record at the same locus carries a different ancestral AA, so the situation is visible in logs.

**`CD8scape.jl`**: adds `--startup-file=no` to all Julia subprocess calls to suppress noisy `REPLExt`/`Pkg` precompilation warnings caused by user startup files loading the REPL.

## Result

| Locus | Before | After |
|---|---|---|
| HA pos 3 | `L3I` only | `I3L` and `L3I` |
| HA pos 160 | `K160I` (wrong), `K160T` | `I160K`, `T160I`, `K160T` |