### PR TITLE
ui: make .pep preview light-themed to match other Output page elements

### DIFF
--- a/ui/app_qt.py
+++ b/ui/app_qt.py
@@ -2068,6 +2068,15 @@ class OutputPage(QWidget):
         )
         _mono.setPointSize(11)
         self._preview_text.setFont(_mono)
+        self._preview_text.setStyleSheet(
+            "QTextEdit {"
+            "  background-color: #ffffff;"
+            "  color: #1d1d1f;"
+            "  border: 1px solid #d1d1d6;"
+            "  border-radius: 7px;"
+            "  font-size: 12px;"
+            "}"
+        )
         self._preview_stack.addWidget(self._preview_text)
 
         self._preview_stack.setCurrentIndex(1)   # start on text pane


### PR DESCRIPTION
The global QTextEdit stylesheet uses a dark terminal theme (#1e1e1e bg, #d4d4d4 text) intended for the Execute-page log widgets. The plain-text preview on the Output page inherited this, making .pep (and .txt/.fasta etc.) files render as an embedded dark terminal panel against the light #f5f5f7 / #ffffff page background.

Fix: add a local setStyleSheet() on _preview_text that overrides the global rule with the same light palette used by the rest of the Output page (white background, #1d1d1f text, matching border/radius).